### PR TITLE
Add product list inside of checkout webpage

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { ReactiveFormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { TopBarComponent } from './top-bar/top-bar.component';
@@ -9,17 +10,20 @@ import { ProductListComponent } from './product-list/product-list.component';
 import { ProductAlertsComponent } from './product-alerts/product-alerts.component';
 import { ProductDetailsComponent } from './product-details/product-details.component';
 import { CartComponent } from './cart/cart.component';
+import { ShippingComponent } from './shipping/shipping.component';
+
 
 @NgModule({
   imports: [
     BrowserModule,
+    HttpClientModule,
     ReactiveFormsModule,
     RouterModule.forRoot([
       { path: '', component: ProductListComponent },
-      { path: 'products/:productId', component: ProductDetailsComponent},
+      { path: 'products/:productId', component: ProductDetailsComponent },
       { path: 'cart', component: CartComponent },
+      { path: 'shipping', component: ShippingComponent },
     ], { useHash: true })
-
   ],
   declarations: [
     AppComponent,
@@ -27,7 +31,8 @@ import { CartComponent } from './cart/cart.component';
     ProductListComponent,
     ProductAlertsComponent,
     ProductDetailsComponent,
-    CartComponent
+    CartComponent,
+    ShippingComponent,
   ],
   bootstrap: [
     AppComponent

--- a/src/app/cart.service.ts
+++ b/src/app/cart.service.ts
@@ -1,11 +1,15 @@
 import { Injectable } from '@angular/core';
 
+import { HttpClient } from '@angular/common/http';
+
 @Injectable({
   providedIn: 'root'
 })
 export class CartService {
 
   items = [];
+
+  constructor(private http: HttpClient) {}
 
   addToCart(product) {
     this.items.push(product);
@@ -20,6 +24,8 @@ export class CartService {
     return this.items;
   }
 
-  constructor() {}
+  getShippingPrices() {
+    return this.http.get('./assets/shipping.json')
+  }
 
 }

--- a/src/app/cart/cart.component.html
+++ b/src/app/cart/cart.component.html
@@ -1,1 +1,6 @@
-<p>cart works!</p>
+<h3>Cart</h3>
+
+<div class="cart-item" *ngFor="let item of items">
+  <span>{{ item.name }}</span>
+  <span>{{ item.price | currency }}</span>
+</div>

--- a/src/app/cart/cart.component.ts
+++ b/src/app/cart/cart.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { CartService } from '../cart.service';
 
 @Component({
   selector: 'app-cart',
@@ -8,7 +9,9 @@ import { Component, OnInit } from '@angular/core';
 
 export class CartComponent implements OnInit {
 
-  constructor() { }
+  items = this.cartService.getItems();
+
+  constructor(private cartService: CartService) { }
 
   ngOnInit(): void {
   }

--- a/src/app/shipping/shipping.component.html
+++ b/src/app/shipping/shipping.component.html
@@ -1,0 +1,1 @@
+<p>shipping works!</p>

--- a/src/app/shipping/shipping.component.spec.ts
+++ b/src/app/shipping/shipping.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShippingComponent } from './shipping.component';
+
+describe('ShippingComponent', () => {
+  let component: ShippingComponent;
+  let fixture: ComponentFixture<ShippingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ShippingComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShippingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shipping/shipping.component.ts
+++ b/src/app/shipping/shipping.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-shipping',
+  templateUrl: './shipping.component.html',
+  styleUrls: ['./shipping.component.css']
+})
+export class ShippingComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
Added a feature that allows items that were "bought" (the user clicked "Buy") to appear inside of the checkout page. Additionally, there is now a webpage for shipping, although it isn't fully implemented currently.